### PR TITLE
chore: upgrade buffer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "browser"
     ],
     "dependencies": {
-        "buffer": "^5.4.3",
+        "buffer": "^6.0.3",
         "readable-stream": "^3.4.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Upgrades to `Buffer@6.x.x` as having multiple versions causes bundle bloat for browsers.