### PR TITLE
fix: add typesVersions to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,18 @@
   "license": "MIT",
   "main": "src/index.js",
   "types": "dist/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*",
+        "dist/src/*"
+      ],
+      "src/*": [
+        "dist/*",
+        "dist/src/*"
+      ]
+    }
+  },
   "engines": {
     "node": ">=10"
   },


### PR DESCRIPTION
You can't deep import `src/random.js` from a typed environment without it.