### PR TITLE
fix: typesVersions for root require

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
   "typesVersions": {
     "*": {
       "*": [
+        "*",
         "dist/*",
         "dist/src/*"
       ],
       "src/*": [
+        "*",
         "dist/*",
         "dist/src/*"
       ]


### PR DESCRIPTION
Adds the wildcard for `"typesVersion"` otherwise this doesn't work:

```js
const { randomBytes } = require('iso-random-stream')
```

Resolution (irrelevant parts removed):

```
Found 'package.json' at '/Users/alex/Documents/Workspaces/ipfs/js-ipfs/node_modules/iso-random-stream/package.json'.
'package.json' has a 'typesVersions' field with version-specific path mappings.
'package.json' has 'types' field 'dist/src/index.d.ts' that references '/Users/alex/Documents/Workspaces/ipfs/js-ipfs/node_modules/iso-random-stream/dist/src/index.d.ts'.
'package.json' has a 'typesVersions' entry '*' that matches compiler version '4.4.4', looking for a pattern to match module name 'dist/src/index.d.ts'.
Module name 'dist/src/index.d.ts', matched pattern '*'.
Trying substitution 'dist/*', candidate module location: 'dist/dist/src/index.d.ts'.
Loading module as file / folder, candidate module location '/Users/alex/Documents/Workspaces/ipfs/js-ipfs/node_modules/iso-random-stream/dist/dist/src/index.d.ts', target file type 'TypeScript'.
Trying substitution 'dist/src/*', candidate module location: 'dist/src/dist/src/index.d.ts'.
Loading module as file / folder, candidate module location '/Users/alex/Documents/Workspaces/ipfs/js-ipfs/node_modules/iso-random-stream/dist/src/dist/src/index.d.ts', target file type 'TypeScript'.
etc
```

So I'm requesting the `index.d.ts`, which it finds in the `"types"` field in `package.json` as `"dist/src/index.d.ts"`, then uses `"typesVersions"` to look up where it is, so it needs the `"*"` wildcard, otherwise it only looks for `"dist/dist/src/index.d.ts"` and `"dist/src/dist/src/index.d.ts"` which don't exist.

This works as expected:

```js
const randomBytes = require('iso-random-stream/src/random')
```